### PR TITLE
changed workflows to build with Go 1.22

### DIFF
--- a/.github/workflows/build-binary.yaml
+++ b/.github/workflows/build-binary.yaml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  go_version: 1.21
+  go_version: 1.22
 
 jobs:
   build:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [ "acex-production" ]
     tags: [ "v*" ]
+  workflow_dispatch:
 
 jobs:
   build-and-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21 AS build
+FROM golang:1.22 AS build
 
 RUN apt-get update -y && \
     apt-get install -y rsync


### PR DESCRIPTION
Build the application with Go 1.22.

Add the possibility of manually dispatching the workflow in the future (no need to add commits if a rebuild is needed)